### PR TITLE
update gemspec metadata

### DIFF
--- a/dependor.gemspec
+++ b/dependor.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.homepage    = "https://github.com/psyho/dependor"
   s.summary     = %q{A couple of classes and modules that simplify dependency injection in Ruby.}
   s.description = %q{Dependor is not a framework for Dependency Injection, but something that reduces duplication a little bit when doing manual dependency injection in settings like Rails apps.}
+  s.license     = "MIT"
 
   s.rubyforge_project = "dependor"
 


### PR DESCRIPTION
This pull request updates a couple of things in the gemspec metadata.
- Correct spelling of "that" in description.
- Use HTTPS for the homepage URL.
- Add MIT license metadata to allow RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
