### PR TITLE
tests: use rspec 3 color configuration API

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,5 +18,5 @@ require 'dependor'
 require 'dependor/shorty'
 
 RSpec.configure do |c|
-  c.color_enabled = true
+  c.color = true
 end


### PR DESCRIPTION
rspec 3.0.0.rc1 removed the `color_enabled` configuration option in favor of the newer `color` option.